### PR TITLE
Update python version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 packages = [{include = "novelai_api"}]
 
 [tool.poetry.dependencies]
-python = ">=3.7.2,<3.11"
+python = ">=3.7.2,<4.0"
 aiohttp = {extras = ["speedups"], version = "^3.8.3"}
 argon2-cffi = "^21.3.0"
 PyNaCl = "^1.5.0"


### PR DESCRIPTION
In theory, all 3.x version should be compatible with the older 3.x versions. Unless a long standing deprecated feature was used, all 3.x versions greater than 3.7.2 will work.

This closes #10